### PR TITLE
Strongly Typed Headers

### DIFF
--- a/src/Microsoft.AspNet.StaticFiles/Constants.cs
+++ b/src/Microsoft.AspNet.StaticFiles/Constants.cs
@@ -11,21 +11,6 @@ namespace Microsoft.AspNet.StaticFiles
         internal const string SendFileVersionKey = "sendfile.Version";
         internal const string SendFileVersion = "1.0";
 
-        internal const string Location = "Location";
-        internal const string IfMatch = "If-Match";
-        internal const string IfNoneMatch = "If-None-Match";
-        internal const string IfModifiedSince = "If-Modified-Since";
-        internal const string IfUnmodifiedSince = "If-Unmodified-Since";
-        internal const string IfRange = "If-Range";
-        internal const string Range = "Range";
-        internal const string ContentRange = "Content-Range";
-        internal const string LastModified = "Last-Modified";
-        internal const string ETag = "ETag";
-
-        internal const string HttpDateFormat = "r";
-
-        internal const string TextHtmlUtf8 = "text/html; charset=utf-8";
-
         internal const int Status200Ok = 200;
         internal const int Status206PartialContent = 206;
         internal const int Status304NotModified = 304;

--- a/src/Microsoft.AspNet.StaticFiles/DefaultFilesMiddleware.cs
+++ b/src/Microsoft.AspNet.StaticFiles/DefaultFilesMiddleware.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.FileSystems;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.StaticFiles
 {
@@ -65,7 +63,7 @@ namespace Microsoft.AspNet.StaticFiles
                             if (!Helpers.PathEndsInSlash(context.Request.Path))
                             {
                                 context.Response.StatusCode = 301;
-                                context.Response.Headers[Constants.Location] = context.Request.PathBase + context.Request.Path + "/" + context.Request.QueryString;
+                                context.Response.Headers[HeaderNames.Location] = context.Request.PathBase + context.Request.Path + "/" + context.Request.QueryString;
                                 return Constants.CompletedTask;
                             }
 

--- a/src/Microsoft.AspNet.StaticFiles/DirectoryBrowserMiddleware.cs
+++ b/src/Microsoft.AspNet.StaticFiles/DirectoryBrowserMiddleware.cs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.FileSystems;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.StaticFiles
 {
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.StaticFiles
                 if (!Helpers.PathEndsInSlash(context.Request.Path))
                 {
                     context.Response.StatusCode = 301;
-                    context.Response.Headers[Constants.Location] = context.Request.PathBase + context.Request.Path + "/" + context.Request.QueryString;
+                    context.Response.Headers[HeaderNames.Location] = context.Request.PathBase + context.Request.Path + "/" + context.Request.QueryString;
                     return Constants.CompletedTask;
                 }
 

--- a/src/Microsoft.AspNet.StaticFiles/Helpers.cs
+++ b/src/Microsoft.AspNet.StaticFiles/Helpers.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
-using System.IO;
 using Microsoft.AspNet.Http;
 
 namespace Microsoft.AspNet.StaticFiles
@@ -44,16 +42,6 @@ namespace Microsoft.AspNet.StaticFiles
                 return true;
             }
             return false;
-        }
-
-        internal static bool TryParseHttpDate(string dateString, out DateTimeOffset parsedDate)
-        {
-            return DateTimeOffset.TryParseExact(dateString, Constants.HttpDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out parsedDate);
-        }
-
-        internal static string ResolveRootPath(string webRoot, PathString path)
-        {
-            return Path.GetFullPath(Path.Combine(webRoot, path.Value ?? string.Empty));
         }
     }
 }

--- a/src/Microsoft.AspNet.StaticFiles/HtmlDirectoryFormatter.cs
+++ b/src/Microsoft.AspNet.StaticFiles/HtmlDirectoryFormatter.cs
@@ -18,6 +18,8 @@ namespace Microsoft.AspNet.StaticFiles
     /// </summary>
     public class HtmlDirectoryFormatter : IDirectoryFormatter
     {
+        private const string TextHtmlUtf8 = "text/html; charset=utf-8";
+
         /// <summary>
         /// Generates an HTML view for a directory.
         /// </summary>
@@ -32,7 +34,7 @@ namespace Microsoft.AspNet.StaticFiles
                 throw new ArgumentNullException("contents");
             }
 
-            context.Response.ContentType = Constants.TextHtmlUtf8;
+            context.Response.ContentType = TextHtmlUtf8;
 
             if (Helpers.IsHeadMethod(context.Request.Method))
             {

--- a/src/Microsoft.AspNet.StaticFiles/HtmlDirectoryFormatter.cs
+++ b/src/Microsoft.AspNet.StaticFiles/HtmlDirectoryFormatter.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNet.StaticFiles
             {
                 builder.AppendFormat(@"
       <tr class=""directory"">
-        <td class=""name""><a href=""{0}/"">{0}/</a></td>
+        <td class=""name""><a href=""./{0}/"">{0}/</a></td>
         <td></td>
         <td class=""modified"">{1}</td>
       </tr>",
@@ -131,7 +131,7 @@ namespace Microsoft.AspNet.StaticFiles
             {
                 builder.AppendFormat(@"
       <tr class=""file"">
-        <td class=""name""><a href=""{0}"">{0}</a></td>
+        <td class=""name""><a href=""./{0}"">{0}</a></td>
         <td class=""length"">{1}</td>
         <td class=""modified"">{2}</td>
       </tr>",

--- a/src/Microsoft.AspNet.StaticFiles/Infrastructure/RangeHelpers.cs
+++ b/src/Microsoft.AspNet.StaticFiles/Infrastructure/RangeHelpers.cs
@@ -3,107 +3,23 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNet.StaticFiles.Infrastructure
 {
     internal static class RangeHelpers
     {
-        // Examples:
-        // bytes=0-499
-        // bytes=500-
-        // bytes=-500
-        // bytes=0-0,-1
-        // bytes=500-600,601-999
-        // Any individual bad range fails the whole parse and the header should be ignored.
-        internal static bool TryParseRanges(string rangeHeader, out IList<Tuple<long?, long?>> parsedRanges)
-        {
-            parsedRanges = null;
-            if (string.IsNullOrWhiteSpace(rangeHeader)
-                || !rangeHeader.StartsWith("bytes=", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            string[] subRanges = rangeHeader.Substring("bytes=".Length).Replace(" ", string.Empty).Split(',');
-
-            List<Tuple<long?, long?>> ranges = new List<Tuple<long?, long?>>();
-
-            for (int i = 0; i < subRanges.Length; i++)
-            {
-                long? first = null, second = null;
-                string subRange = subRanges[i];
-                int dashIndex = subRange.IndexOf('-');
-                if (dashIndex < 0)
-                {
-                    return false;
-                }
-                else if (dashIndex == 0)
-                {
-                    // -500
-                    string remainder = subRange.Substring(1);
-                    if (!TryParseLong(remainder, out second))
-                    {
-                        return false;
-                    }
-                }
-                else if (dashIndex == (subRange.Length - 1))
-                {
-                    // 500-
-                    string remainder = subRange.Substring(0, subRange.Length - 1);
-                    if (!TryParseLong(remainder, out first))
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    // 0-499
-                    string firstString = subRange.Substring(0, dashIndex);
-                    string secondString = subRange.Substring(dashIndex + 1, subRange.Length - dashIndex - 1);
-                    if (!TryParseLong(firstString, out first) || !TryParseLong(secondString, out second)
-                        || first.Value > second.Value)
-                    {
-                        return false;
-                    }
-                }
-
-                ranges.Add(new Tuple<long?, long?>(first, second));
-            }
-
-            if (ranges.Count > 0)
-            {
-                parsedRanges = ranges;
-                return true;
-            }
-            return false;
-        }
-
-        private static bool TryParseLong(string input, out long? result)
-        {
-            int temp;
-            if (!string.IsNullOrWhiteSpace(input)
-                && int.TryParse(input, NumberStyles.None, CultureInfo.InvariantCulture, out temp))
-            {
-                result = temp;
-                return true;
-            }
-            result = null;
-            return false;
-        }
-
         // 14.35.1 Byte Ranges - If a syntactically valid byte-range-set includes at least one byte-range-spec whose
         // first-byte-pos is less than the current length of the entity-body, or at least one suffix-byte-range-spec
         // with a non-zero suffix-length, then the byte-range-set is satisfiable.
         // Adjusts ranges to be absolute and within bounds.
-        internal static IList<Tuple<long, long>> NormalizeRanges(IList<Tuple<long?, long?>> ranges, long length)
+        internal static IList<RangeItemHeaderValue> NormalizeRanges(ICollection<RangeItemHeaderValue> ranges, long length)
         {
-            IList<Tuple<long, long>> normalizedRanges = new List<Tuple<long, long>>(ranges.Count);
-            for (int i = 0; i < ranges.Count; i++)
+            IList<RangeItemHeaderValue> normalizedRanges = new List<RangeItemHeaderValue>(ranges.Count);
+            foreach (var range in ranges)
             {
-                Tuple<long?, long?> range = ranges[i];
-                long? start = range.Item1, end = range.Item2;
+                long? start = range.From;
+                long? end = range.To;
 
                 // X-[Y]
                 if (start.HasValue)
@@ -131,7 +47,7 @@ namespace Microsoft.AspNet.StaticFiles.Infrastructure
                     start = length - bytes;
                     end = start + bytes - 1;
                 }
-                normalizedRanges.Add(new Tuple<long, long>(start.Value, end.Value));
+                normalizedRanges.Add(new RangeItemHeaderValue(start.Value, end.Value));
             }
             return normalizedRanges;
         }

--- a/src/Microsoft.AspNet.StaticFiles/Microsoft.AspNet.StaticFiles.kproj
+++ b/src/Microsoft.AspNet.StaticFiles/Microsoft.AspNet.StaticFiles.kproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -14,4 +14,9 @@
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />
+    </VisualStudio>
+  </ProjectExtensions>
 </Project>


### PR DESCRIPTION
Use the new strongly typed headers to simplify the static files code. This primarily affects range requests.

Related:
#18 Send the Accept-Ranges header.
https://github.com/aspnet/HttpAbstractions/pull/164 - New header types

@muratg @davidfowl @loudej @GrabYourPitchforks