### PR TITLE
Make tests run on CoreCLR

### DIFF
--- a/test/Microsoft.AspNet.StaticFiles.Tests/CacheHeaderTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/CacheHeaderTests.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.TestHost;
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.StaticFiles
@@ -19,8 +18,8 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseFileServer());
 
             HttpResponseMessage response = await server.CreateClient().GetAsync("http://localhost/SubFolder/Extra.xml");
-            response.Headers.ETag.ShouldNotBe(null);
-            response.Headers.ETag.Tag.ShouldNotBe(null);
+            Assert.NotNull(response.Headers.ETag);
+            Assert.NotNull(response.Headers.ETag.Tag);
         }
 
         [Fact]
@@ -30,7 +29,7 @@ namespace Microsoft.AspNet.StaticFiles
 
             HttpResponseMessage response1 = await server.CreateClient().GetAsync("http://localhost/SubFolder/Extra.xml");
             HttpResponseMessage response2 = await server.CreateClient().GetAsync("http://localhost/SubFolder/Extra.xml");
-            response1.Headers.ETag.ShouldBe(response2.Headers.ETag);
+            Assert.Equal(response2.Headers.ETag, response1.Headers.ETag);
         }
 
         // 14.24 If-Match
@@ -48,7 +47,7 @@ namespace Microsoft.AspNet.StaticFiles
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/Extra.xml");
             req.Headers.Add("If-Match", "\"fake\"");
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
-            resp.StatusCode.ShouldBe(HttpStatusCode.PreconditionFailed);
+            Assert.Equal(HttpStatusCode.PreconditionFailed, resp.StatusCode);
         }
 
         [Fact]
@@ -60,7 +59,7 @@ namespace Microsoft.AspNet.StaticFiles
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/Extra.xml");
             req.Headers.Add("If-Match", original.Headers.ETag.ToString());
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
-            resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         }
 
         [Fact]
@@ -70,7 +69,7 @@ namespace Microsoft.AspNet.StaticFiles
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/Extra.xml");
             req.Headers.Add("If-Match", "*");
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
-            resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         }
 
         // 14.26 If-None-Match
@@ -96,12 +95,12 @@ namespace Microsoft.AspNet.StaticFiles
             var req2 = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/Extra.xml");
             req2.Headers.Add("If-None-Match", resp1.Headers.ETag.ToString());
             HttpResponseMessage resp2 = await server.CreateClient().SendAsync(req2);
-            resp2.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+            Assert.Equal(HttpStatusCode.NotModified, resp2.StatusCode);
 
             var req3 = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/Extra.xml");
             req3.Headers.Add("If-None-Match", resp1.Headers.ETag.ToString());
             HttpResponseMessage resp3 = await server.CreateClient().SendAsync(req3);
-            resp3.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+            Assert.Equal(HttpStatusCode.NotModified, resp3.StatusCode);
         }
 
         [Fact]
@@ -113,12 +112,12 @@ namespace Microsoft.AspNet.StaticFiles
             var req2 = new HttpRequestMessage(HttpMethod.Post, "http://localhost/SubFolder/Extra.xml");
             req2.Headers.Add("If-None-Match", resp1.Headers.ETag.ToString());
             HttpResponseMessage resp2 = await server.CreateClient().SendAsync(req2);
-            resp2.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, resp2.StatusCode);
 
             var req3 = new HttpRequestMessage(HttpMethod.Put, "http://localhost/SubFolder/Extra.xml");
             req3.Headers.Add("If-None-Match", resp1.Headers.ETag.ToString());
             HttpResponseMessage resp3 = await server.CreateClient().SendAsync(req3);
-            resp3.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+            Assert.Equal(HttpStatusCode.NotFound, resp3.StatusCode);
         }
 
         // 14.26 If-None-Match
@@ -137,7 +136,7 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseFileServer());
 
             HttpResponseMessage response = await server.CreateClient().GetAsync("http://localhost/SubFolder/Extra.xml");
-            response.Content.Headers.LastModified.ShouldNotBe(null);
+            Assert.NotNull(response.Content.Headers.LastModified);
         }
 
         // 13.3.4
@@ -163,7 +162,7 @@ namespace Microsoft.AspNet.StaticFiles
                 .And(req => req.Headers.IfModifiedSince = resp1.Content.Headers.LastModified)
                 .GetAsync();
 
-            resp2.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+            Assert.Equal(HttpStatusCode.NotModified, resp2.StatusCode);
         }
 
         [Fact]
@@ -196,9 +195,9 @@ namespace Microsoft.AspNet.StaticFiles
                 .And(req => req.Headers.IfModifiedSince = furtureDate)
                 .GetAsync();
 
-            resp2.StatusCode.ShouldBe(HttpStatusCode.OK);
-            resp3.StatusCode.ShouldBe(HttpStatusCode.OK);
-            resp4.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, resp2.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, resp3.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, resp4.StatusCode);
         }
 
         // 14.25 If-Modified-Since
@@ -223,7 +222,7 @@ namespace Microsoft.AspNet.StaticFiles
                 .AddHeader("If-Modified-Since", "bad-date")
                 .GetAsync();
 
-            res.StatusCode.ShouldBe(HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, res.StatusCode);
         }
 
         // b) If the variant has been modified since the If-Modified-Since
@@ -247,7 +246,7 @@ namespace Microsoft.AspNet.StaticFiles
                 .And(req => req.Headers.IfModifiedSince = res1.Content.Headers.LastModified)
                 .GetAsync();
 
-            res2.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+            Assert.Equal(HttpStatusCode.NotModified, res2.StatusCode);
         }
     }
 }

--- a/test/Microsoft.AspNet.StaticFiles.Tests/DefaultContentTypeProviderTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/DefaultContentTypeProviderTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved. See License.txt in the project root for license information.
 
-using Shouldly;
 using Xunit;
 
 namespace Microsoft.AspNet.StaticFiles
@@ -12,7 +11,7 @@ namespace Microsoft.AspNet.StaticFiles
         {
             var provider = new FileExtensionContentTypeProvider();
             string contentType;
-            provider.TryGetContentType("unknown.ext", out contentType).ShouldBe(false);
+            Assert.False(provider.TryGetContentType("unknown.ext", out contentType));
         }
 
         [Fact]
@@ -20,8 +19,8 @@ namespace Microsoft.AspNet.StaticFiles
         {
             var provider = new FileExtensionContentTypeProvider();
             string contentType;
-            provider.TryGetContentType("known.txt", out contentType).ShouldBe(true);
-            contentType.ShouldBe("text/plain");
+            Assert.True(provider.TryGetContentType("known.txt", out contentType));
+            Assert.Equal("text/plain", contentType);
         }
 
         [Fact]
@@ -29,7 +28,7 @@ namespace Microsoft.AspNet.StaticFiles
         {
             var provider = new FileExtensionContentTypeProvider();
             string contentType;
-            provider.TryGetContentType("known.exe.config", out contentType).ShouldBe(false);
+            Assert.False(provider.TryGetContentType("known.exe.config", out contentType));
         }
 
         [Fact]
@@ -37,8 +36,8 @@ namespace Microsoft.AspNet.StaticFiles
         {
             var provider = new FileExtensionContentTypeProvider();
             string contentType;
-            provider.TryGetContentType("known.dvr-ms", out contentType).ShouldBe(true);
-            contentType.ShouldBe("video/x-ms-dvr");
+            Assert.True(provider.TryGetContentType("known.dvr-ms", out contentType));
+            Assert.Equal("video/x-ms-dvr", contentType);
         }
 
         [Fact]
@@ -46,10 +45,10 @@ namespace Microsoft.AspNet.StaticFiles
         {
             var provider = new FileExtensionContentTypeProvider();
             string contentType;
-            provider.TryGetContentType(@"/first/example.txt", out contentType).ShouldBe(true);
-            contentType.ShouldBe("text/plain");
-            provider.TryGetContentType(@"\second\example.txt", out contentType).ShouldBe(true);
-            contentType.ShouldBe("text/plain");
+            Assert.True(provider.TryGetContentType(@"/first/example.txt", out contentType));
+            Assert.Equal("text/plain", contentType);
+            Assert.True(provider.TryGetContentType(@"\second\example.txt", out contentType));
+            Assert.Equal("text/plain", contentType);
         }
 
         [Fact]
@@ -57,10 +56,10 @@ namespace Microsoft.AspNet.StaticFiles
         {
             var provider = new FileExtensionContentTypeProvider();
             string contentType;
-            provider.TryGetContentType(@"/first.css/example.txt", out contentType).ShouldBe(true);
-            contentType.ShouldBe("text/plain");
-            provider.TryGetContentType(@"\second.css\example.txt", out contentType).ShouldBe(true);
-            contentType.ShouldBe("text/plain");
+            Assert.True(provider.TryGetContentType(@"/first.css/example.txt", out contentType));
+            Assert.Equal("text/plain", contentType);
+            Assert.True(provider.TryGetContentType(@"\second.css\example.txt", out contentType));
+            Assert.Equal("text/plain", contentType);
         }
     }
 }

--- a/test/Microsoft.AspNet.StaticFiles.Tests/DefaultFilesMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/DefaultFilesMiddlewareTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.StaticFiles
                 app.UseDefaultFiles(new DefaultFilesOptions()
                 {
                     RequestPath = new PathString(baseUrl),
-                    FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
                 });
                 app.Run(context => context.Response.WriteAsync(context.Request.Path.Value));
             });
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.StaticFiles
                 app.UseDefaultFiles(new DefaultFilesOptions()
                 {
                     RequestPath = new PathString(baseUrl),
-                    FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
                 });
                 app.Run(context => context.Response.WriteAsync(context.Request.Path.Value));
             });
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions()
             {
                 RequestPath = new PathString(baseUrl),
-                FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
             }));
             HttpResponseMessage response = await server.CreateRequest(requestUrl + queryString).GetAsync();
 
@@ -100,7 +100,7 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions()
             {
                 RequestPath = new PathString(baseUrl),
-                FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
             }));
             HttpResponseMessage response = await server.CreateRequest(requestUrl).GetAsync();
 

--- a/test/Microsoft.AspNet.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.StaticFiles
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
-                    FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
                 }),
                 services => services.AddDirectoryBrowser());
             HttpResponseMessage response = await server.CreateRequest(requestUrl).GetAsync();
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.StaticFiles
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
-                    FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
                 }),
                 services => services.AddDirectoryBrowser());
             HttpResponseMessage response = await server.CreateRequest(requestUrl).GetAsync();
@@ -92,7 +92,7 @@ namespace Microsoft.AspNet.StaticFiles
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
-                    FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
                 }),
                 services => services.AddDirectoryBrowser());
 
@@ -114,7 +114,7 @@ namespace Microsoft.AspNet.StaticFiles
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
-                    FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
                 }),
                 services => services.AddDirectoryBrowser());
 
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.StaticFiles
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
-                    FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
                 }),
                 services => services.AddDirectoryBrowser());
 

--- a/test/Microsoft.AspNet.StaticFiles.Tests/StaticFileMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/StaticFileMiddlewareTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
-                FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
             }));
             HttpResponseMessage response = await server.CreateRequest(requestUrl).GetAsync();
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
-                FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
             }));
             HttpResponseMessage response = await server.CreateRequest(requestUrl).GetAsync();
 
@@ -80,7 +80,7 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
-                FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
             }));
             HttpResponseMessage response = await server.CreateRequest(requestUrl).PostAsync();
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.StaticFiles
             TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
-                FileProvider = new PhysicalFileProvider(Path.Combine(Environment.CurrentDirectory, baseDir))
+                FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
             }));
             HttpResponseMessage response = await server.CreateRequest(requestUrl).SendAsync("HEAD");
 

--- a/test/Microsoft.AspNet.StaticFiles.Tests/project.json
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/project.json
@@ -9,10 +9,7 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": {
-            "dependencies": {
-                "Shouldly": "1.1.1.1"
-            }
-        }
+        "dnx451": { },
+        "dnxcore50": { }
     }
 }


### PR DESCRIPTION
- Added dnxcore50 target
- Removed Shouldly reference
- Used CoreCLR-compatible APIs

Note: Tests were already failing on Travis on Mono; will investigate them later.