### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.StaticFiles/FileExtensionContentTypeProvider.cs
+++ b/src/Microsoft.AspNet.StaticFiles/FileExtensionContentTypeProvider.cs
@@ -404,7 +404,7 @@ namespace Microsoft.AspNet.StaticFiles
         {
             if (mapping == null)
             {
-                throw new ArgumentNullException("mapping");
+                throw new ArgumentNullException(nameof(mapping));
             }
             Mappings = mapping;
         }

--- a/src/Microsoft.AspNet.StaticFiles/FileServerExtensions.cs
+++ b/src/Microsoft.AspNet.StaticFiles/FileServerExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNet.Builder
         {
             if (options == null)
             {
-                throw new ArgumentNullException("options");
+                throw new ArgumentNullException(nameof(options));
             }
 
             if (options.EnableDefaultFiles)

--- a/src/Microsoft.AspNet.StaticFiles/HtmlDirectoryFormatter.cs
+++ b/src/Microsoft.AspNet.StaticFiles/HtmlDirectoryFormatter.cs
@@ -29,11 +29,11 @@ namespace Microsoft.AspNet.StaticFiles
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
             if (contents == null)
             {
-                throw new ArgumentNullException("contents");
+                throw new ArgumentNullException(nameof(contents));
             }
 
             if (_htmlEncoder == null)

--- a/src/Microsoft.AspNet.StaticFiles/Infrastructure/SharedOptionsBase.cs
+++ b/src/Microsoft.AspNet.StaticFiles/Infrastructure/SharedOptionsBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.StaticFiles.Infrastructure
         {
             if (sharedOptions == null)
             {
-                throw new ArgumentNullException("sharedOptions");
+                throw new ArgumentNullException(nameof(sharedOptions));
             }
 
             SharedOptions = sharedOptions;

--- a/src/Microsoft.AspNet.StaticFiles/SendFileMiddleware.cs
+++ b/src/Microsoft.AspNet.StaticFiles/SendFileMiddleware.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.StaticFiles
 
                 if (string.IsNullOrWhiteSpace(fileName))
                 {
-                    throw new ArgumentNullException("fileName");
+                    throw new ArgumentNullException(nameof(fileName));
                 }
                 if (!File.Exists(fileName))
                 {


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason