### PR TITLE
React to wwwroot hosting changes

### DIFF
--- a/test/Microsoft.AspNet.StaticFiles.Tests/CacheHeaderTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/CacheHeaderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task ServerShouldReturnETag()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
 
             HttpResponseMessage response = await server.CreateClient().GetAsync("http://localhost/SubFolder/extra.xml");
             Assert.NotNull(response.Headers.ETag);
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task SameETagShouldBeReturnedAgain()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
 
             HttpResponseMessage response1 = await server.CreateClient().GetAsync("http://localhost/SubFolder/extra.xml");
             HttpResponseMessage response2 = await server.CreateClient().GetAsync("http://localhost/SubFolder/extra.xml");
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfMatchShouldReturn412WhenNotListed()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/extra.xml");
             req.Headers.Add("If-Match", "\"fake\"");
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfMatchShouldBeServedWhenListed()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/extra.xml");
 
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/extra.xml");
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfMatchShouldBeServedForAstrisk()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/extra.xml");
             req.Headers.Add("If-Match", "*");
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfNoneMatchShouldReturn304ForMatchingOnGetAndHeadMethod()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage resp1 = await server.CreateClient().GetAsync("http://localhost/SubFolder/extra.xml");
 
             var req2 = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/extra.xml");
@@ -107,7 +107,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfNoneMatchShouldBeIgnoredForNonTwoHundredAnd304Responses()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage resp1 = await server.CreateClient().GetAsync("http://localhost/SubFolder/extra.xml");
 
             var req2 = new HttpRequestMessage(HttpMethod.Post, "http://localhost/SubFolder/extra.xml");
@@ -134,7 +134,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task ServerShouldReturnLastModified()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
 
             HttpResponseMessage response = await server.CreateClient().GetAsync("http://localhost/SubFolder/extra.xml");
             Assert.NotNull(response.Content.Headers.LastModified);
@@ -152,7 +152,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task MatchingBothConditionsReturnsNotModified()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage resp1 = await server
                 .CreateRequest("/SubFolder/extra.xml")
                 .GetAsync();
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task MissingEitherOrBothConditionsReturnsNormally()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage resp1 = await server
                 .CreateRequest("/SubFolder/extra.xml")
                 .GetAsync();
@@ -216,7 +216,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task InvalidIfModifiedSinceDateFormatGivesNormalGet()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
 
             HttpResponseMessage res = await server
                 .CreateRequest("/SubFolder/extra.xml")
@@ -236,7 +236,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfModifiedSinceDateEqualsLastModifiedShouldReturn304()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
 
             HttpResponseMessage res1 = await server
                 .CreateRequest("/SubFolder/extra.xml")

--- a/test/Microsoft.AspNet.StaticFiles.Tests/DefaultFilesMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/DefaultFilesMiddlewareTests.cs
@@ -21,10 +21,10 @@ namespace Microsoft.AspNet.StaticFiles
         public async Task NullArguments()
         {
             // No exception, default provided
-            TestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions() { FileProvider = null }));
+            StaticFilesTestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions() { FileProvider = null }));
 
             // PathString(null) is OK.
-            TestServer server = TestServer.Create(app => app.UseDefaultFiles((string)null));
+            TestServer server = StaticFilesTestServer.Create(app => app.UseDefaultFiles((string)null));
             var response = await server.CreateClient().GetAsync("/");
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
@@ -52,7 +52,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task NoMatch_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(app =>
+            TestServer server = StaticFilesTestServer.Create(app =>
             {
                 app.UseDefaultFiles(new DefaultFilesOptions()
                 {
@@ -88,7 +88,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task FoundDirectoryWithDefaultFile_PathModified(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(app =>
+            TestServer server = StaticFilesTestServer.Create(app =>
             {
                 app.UseDefaultFiles(new DefaultFilesOptions()
                 {
@@ -124,7 +124,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task NearMatch_RedirectAddSlash(string baseUrl, string baseDir, string requestUrl, string queryString)
         {
-            TestServer server = TestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions()
+            TestServer server = StaticFilesTestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions()
             {
                 RequestPath = new PathString(baseUrl),
                 FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
@@ -159,7 +159,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task PostDirectory_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions()
+            TestServer server = StaticFilesTestServer.Create(app => app.UseDefaultFiles(new DefaultFilesOptions()
             {
                 RequestPath = new PathString(baseUrl),
                 FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))

--- a/test/Microsoft.AspNet.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
@@ -22,17 +22,17 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task NullArguments()
         {
-            Assert.Throws<ArgumentException>(() => TestServer.Create(
+            Assert.Throws<ArgumentException>(() => StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions() { Formatter = null }),
             services => services.AddDirectoryBrowser()));
 
             // No exception, default provided
-            TestServer.Create(
+            StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions() { FileProvider = null }),
                 services => services.AddDirectoryBrowser());
 
             // PathString(null) is OK.
-            TestServer server = TestServer.Create(
+            TestServer server = StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser((string)null),
                 services => services.AddDirectoryBrowser());
 
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task NoMatch_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(
+            TestServer server = StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
@@ -97,7 +97,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task FoundDirectory_Served(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(
+            TestServer server = StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
@@ -136,7 +136,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task NearMatch_RedirectAddSlash(string baseUrl, string baseDir, string requestUrl, string queryString)
         {
-            TestServer server = TestServer.Create(
+            TestServer server = StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
@@ -172,7 +172,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task PostDirectory_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(
+            TestServer server = StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),
@@ -205,7 +205,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task HeadDirectory_HeadersButNotBodyServed(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(
+            TestServer server = StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions()
                 {
                     RequestPath = new PathString(baseUrl),

--- a/test/Microsoft.AspNet.StaticFiles.Tests/RangeHeaderTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/RangeHeaderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfRangeWithCurrentEtagShouldServePartialContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task HEADIfRangeWithCurrentEtagShouldReturn200Ok()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfRangeWithCurrentDateShouldServePartialContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task HEADIfRangeWithCurrentDateShouldReturn200Ok()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfRangeWithOldEtagShouldServeFullContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
             req.Headers.Add("If-Range", "\"OldEtag\"");
             req.Headers.Add("Range", "bytes=0-10");
@@ -114,7 +114,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task HEADIfRangeWithOldEtagShouldServeFullContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
             req.Headers.Add("If-Range", "\"OldEtag\"");
             req.Headers.Add("Range", "bytes=0-10");
@@ -130,7 +130,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfRangeWithOldDateShouldServeFullContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
@@ -148,7 +148,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task HEADIfRangeWithOldDateShouldServeFullContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
@@ -167,7 +167,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task IfRangeWithoutRangeShouldServeFullContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
@@ -193,7 +193,7 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task HEADIfRangeWithoutRangeShouldServeFullContent()
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             HttpResponseMessage original = await server.CreateClient().GetAsync("http://localhost/SubFolder/ranges.txt");
 
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
@@ -225,7 +225,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("-1001", "0-61", 62, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")]
         public async Task SingleValidRangeShouldServePartialContent(string range, string expectedRange, int length, string expectedData)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
             req.Headers.Add("Range", "bytes=" + range);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -242,7 +242,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("10-35")]
         public async Task HEADSingleValidRangeShouldReturnOk(string range)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
             req.Headers.Add("Range", "bytes=" + range);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -259,7 +259,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("-0")] // Suffix range must be non-zero
         public async Task SingleNotSatisfiableRange(string range)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
             req.Headers.TryAddWithoutValidation("Range", "bytes=" + range);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -273,7 +273,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("1000-1001")] // Out of range
         public async Task HEADSingleNotSatisfiableRangeReturnsOk(string range)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
             req.Headers.TryAddWithoutValidation("Range", "bytes=" + range);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -289,7 +289,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("-")]
         public async Task SingleInvalidRangeIgnored(string range)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
             req.Headers.TryAddWithoutValidation("Range", "bytes=" + range);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -307,7 +307,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("-")]
         public async Task HEADSingleInvalidRangeIgnored(string range)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
             req.Headers.TryAddWithoutValidation("Range", "bytes=" + range);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -327,7 +327,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("0-0,6-6,8-8,2-2,4-4")]
         public async Task MultipleValidRangesShouldServeFullContent(string ranges)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Get, "http://localhost/SubFolder/ranges.txt");
             req.Headers.Add("Range", "bytes=" + ranges);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);
@@ -346,7 +346,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("2-2,0-0")] // SHOULD send in the requested order.
         public async Task HEADMultipleValidRangesShouldServeFullContent(string range)
         {
-            TestServer server = TestServer.Create(app => app.UseFileServer());
+            TestServer server = StaticFilesTestServer.Create(app => app.UseFileServer());
             var req = new HttpRequestMessage(HttpMethod.Head, "http://localhost/SubFolder/ranges.txt");
             req.Headers.Add("Range", "bytes=" + range);
             HttpResponseMessage resp = await server.CreateClient().SendAsync(req);

--- a/test/Microsoft.AspNet.StaticFiles.Tests/StaticFileMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/StaticFileMiddlewareTests.cs
@@ -20,13 +20,13 @@ namespace Microsoft.AspNet.StaticFiles
         [Fact]
         public async Task NullArguments()
         {
-            Assert.Throws<ArgumentException>(() => TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions() { ContentTypeProvider = null })));
+            Assert.Throws<ArgumentException>(() => StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions() { ContentTypeProvider = null })));
 
             // No exception, default provided
-            TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions() { FileProvider = null }));
+            StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions() { FileProvider = null }));
 
             // PathString(null) is OK.
-            TestServer server = TestServer.Create(app => app.UseStaticFiles((string)null));
+            TestServer server = StaticFilesTestServer.Create(app => app.UseStaticFiles((string)null));
             var response = await server.CreateClient().GetAsync("/");
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("", @"./", "/xunit.xml")]
         public async Task NoMatch_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
+            TestServer server = StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
                 FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.StaticFiles
 
         public async Task FoundFile_Served(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
+            TestServer server = StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
                 FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
@@ -93,7 +93,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("/somedir", @"SubFolder", "/somedir/ranges.txt")]
         public async Task PostFile_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
+            TestServer server = StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
                 FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))
@@ -110,7 +110,7 @@ namespace Microsoft.AspNet.StaticFiles
         [InlineData("/somedir", @"SubFolder", "/somedir/ranges.txt")]
         public async Task HeadFile_HeadersButNotBodyServed(string baseUrl, string baseDir, string requestUrl)
         {
-            TestServer server = TestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
+            TestServer server = StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions()
             {
                 RequestPath = new PathString(baseUrl),
                 FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), baseDir))

--- a/test/Microsoft.AspNet.StaticFiles.Tests/StaticFilesTestServer.cs
+++ b/test/Microsoft.AspNet.StaticFiles.Tests/StaticFilesTestServer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNet.StaticFiles
+{
+    public static class StaticFilesTestServer
+    {
+        public static TestServer Create(Action<IApplicationBuilder> configureApp, Action<IServiceCollection> configureServices = null)
+        {
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(new []
+            {
+                new KeyValuePair<string, string>("webroot", ".")
+            });
+            return TestServer.Create(configurationBuilder.Build(), configureApp, configureServices: configureServices);
+        }
+    }
+}


### PR DESCRIPTION
Reacts to https://github.com/aspnet/Hosting/pull/493
Now server does not automatically falls back to `approot` as `webroot`. So `webroot` needs to be specified explicitly

@JunTaoLuo @BrennanConroy @Tratcher @victorhurdugaci 