### PR TITLE
Remove GetRequiredService

### DIFF
--- a/src/Microsoft.AspNetCore.StaticFiles/DefaultFilesOptions.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/DefaultFilesOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Options for selecting default file names.
     /// </summary>
-    public class DefaultFilesOptions : SharedOptionsBase<DefaultFilesOptions>
+    public class DefaultFilesOptions : SharedOptionsBase
     {
         /// <summary>
         /// Configuration for the DefaultFilesMiddleware.

--- a/src/Microsoft.AspNetCore.StaticFiles/DirectoryBrowserMiddleware.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/DirectoryBrowserMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -26,8 +27,9 @@ namespace Microsoft.AspNetCore.StaticFiles
         /// </summary>
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="hostingEnv">The <see cref="IHostingEnvironment"/> used by this middleware.</param>
+        /// <param name="encoder">The <see cref="HtmlEncoder"/> used by the default <see cref="HtmlDirectoryFormatter"/>.</param>
         /// <param name="options">The configuration for this middleware.</param>
-        public DirectoryBrowserMiddleware(RequestDelegate next, IHostingEnvironment hostingEnv, IOptions<DirectoryBrowserOptions> options)
+        public DirectoryBrowserMiddleware(RequestDelegate next, IHostingEnvironment hostingEnv, HtmlEncoder encoder, IOptions<DirectoryBrowserOptions> options)
         {
             if (next == null)
             {
@@ -39,6 +41,11 @@ namespace Microsoft.AspNetCore.StaticFiles
                 throw new ArgumentNullException(nameof(hostingEnv));
             }
 
+            if (encoder == null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
+
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
@@ -46,7 +53,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
             if (options.Value.Formatter == null)
             {
-                throw new ArgumentException(Resources.Args_NoFormatter);
+                options.Value.Formatter = new HtmlDirectoryFormatter(encoder);
             }
 
             _next = next;

--- a/src/Microsoft.AspNetCore.StaticFiles/DirectoryBrowserOptions.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/DirectoryBrowserOptions.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Builder
         public DirectoryBrowserOptions(SharedOptions sharedOptions)
             : base(sharedOptions)
         {
-            Formatter = new HtmlDirectoryFormatter();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.StaticFiles/DirectoryBrowserOptions.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/DirectoryBrowserOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Directory browsing options
     /// </summary>
-    public class DirectoryBrowserOptions : SharedOptionsBase<DirectoryBrowserOptions>
+    public class DirectoryBrowserOptions : SharedOptionsBase
     {
         /// <summary>
         /// Enabled directory browsing for all request paths

--- a/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Microsoft.AspNetCore.StaticFiles
 {

--- a/src/Microsoft.AspNetCore.StaticFiles/FileProvider.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileProvider.cs
@@ -1,6 +1,0 @@
-﻿namespace Microsoft.AspNetCore.StaticFiles
-{
-    internal class FileProvider
-    {
-    }
-}

--- a/src/Microsoft.AspNetCore.StaticFiles/FileProvider.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.AspNetCore.StaticFiles
+{
+    internal class FileProvider
+    {
+    }
+}

--- a/src/Microsoft.AspNetCore.StaticFiles/FileServerOptions.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileServerOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Options for all of the static file middleware components
     /// </summary>
-    public class FileServerOptions : SharedOptionsBase<FileServerOptions>
+    public class FileServerOptions : SharedOptionsBase
     {
         /// <summary>
         /// Creates a combined options class for all of the static file middleware components.

--- a/src/Microsoft.AspNetCore.StaticFiles/Helpers.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/Helpers.cs
@@ -2,12 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.StaticFiles
 {
     internal static class Helpers
     {
+        internal static IFileProvider ResolveFileProvider(IHostingEnvironment hostingEnv)
+        {
+            if (hostingEnv.WebRootFileProvider == null) {
+                throw new InvalidOperationException("Missing FileProvider.");
+            }
+            return hostingEnv.WebRootFileProvider;
+        }
+
+
         internal static bool IsGetOrHeadMethod(string method)
         {
             return IsGetMethod(method) || IsHeadMethod(method);

--- a/src/Microsoft.AspNetCore.StaticFiles/HtmlDirectoryFormatter.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/HtmlDirectoryFormatter.cs
@@ -23,6 +23,15 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         private HtmlEncoder _htmlEncoder;
 
+        public HtmlDirectoryFormatter(HtmlEncoder encoder)
+        {
+            if (encoder == null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
+            _htmlEncoder = encoder;
+        } 
+
         /// <summary>
         /// Generates an HTML view for a directory.
         /// </summary>
@@ -35,11 +44,6 @@ namespace Microsoft.AspNetCore.StaticFiles
             if (contents == null)
             {
                 throw new ArgumentNullException(nameof(contents));
-            }
-
-            if (_htmlEncoder == null)
-            {
-                _htmlEncoder = context.RequestServices.GetRequiredService<HtmlEncoder>();
             }
 
             context.Response.ContentType = TextHtmlUtf8;

--- a/src/Microsoft.AspNetCore.StaticFiles/Infrastructure/SharedOptionsBase.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/Infrastructure/SharedOptionsBase.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 
@@ -11,8 +10,7 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
     /// <summary>
     /// Options common to several middleware components
     /// </summary>
-    /// <typeparam name="T">The type of the subclass</typeparam>
-    public abstract class SharedOptionsBase<T>
+    public abstract class SharedOptionsBase
     {
         /// <summary>
         /// Creates an new instance of the SharedOptionsBase.
@@ -49,18 +47,6 @@ namespace Microsoft.AspNetCore.StaticFiles.Infrastructure
         {
             get { return SharedOptions.FileProvider; }
             set { SharedOptions.FileProvider = value; }
-        }
-
-        internal void ResolveFileProvider(IHostingEnvironment hostingEnv)
-        {
-            if (FileProvider == null)
-            {
-                FileProvider = hostingEnv.WebRootFileProvider;
-                if (FileProvider == null)
-                {
-                    throw new InvalidOperationException("Missing FileProvider.");
-                }
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.StaticFiles/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/Resources.Designer.cs
@@ -11,22 +11,6 @@ namespace Microsoft.AspNetCore.StaticFiles
             = new ResourceManager("Microsoft.AspNetCore.StaticFiles.Resources", typeof(Resources).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// No IContentTypeProvider was specified.
-        /// </summary>
-        internal static string Args_NoContentTypeProvider
-        {
-            get { return GetString("Args_NoContentTypeProvider"); }
-        }
-
-        /// <summary>
-        /// No IContentTypeProvider was specified.
-        /// </summary>
-        internal static string FormatArgs_NoContentTypeProvider()
-        {
-            return GetString("Args_NoContentTypeProvider");
-        }
-
-        /// <summary>
         /// No formatter provided.
         /// </summary>
         internal static string Args_NoFormatter

--- a/src/Microsoft.AspNetCore.StaticFiles/Resources.resx
+++ b/src/Microsoft.AspNetCore.StaticFiles/Resources.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Args_NoContentTypeProvider" xml:space="preserve">
-    <value>No IContentTypeProvider was specified.</value>
-  </data>
   <data name="Args_NoFormatter" xml:space="preserve">
     <value>No formatter provided.</value>
   </data>

--- a/src/Microsoft.AspNetCore.StaticFiles/StaticFileContext.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/StaticFileContext.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         private readonly HttpRequest _request;
         private readonly HttpResponse _response;
         private readonly ILogger _logger;
+        private readonly IFileProvider _fileProvider;
         private string _method;
         private bool _isGet;
         private bool _isHead;
@@ -47,7 +48,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         private IList<RangeItemHeaderValue> _ranges;
 
-        public StaticFileContext(HttpContext context, StaticFileOptions options, PathString matchUrl, ILogger logger)
+        public StaticFileContext(HttpContext context, StaticFileOptions options, PathString matchUrl, ILogger logger, IFileProvider fileProvider)
         {
             _context = context;
             _options = options;
@@ -57,6 +58,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             _logger = logger;
             _requestHeaders = _request.GetTypedHeaders();
             _responseHeaders = _response.GetTypedHeaders();
+            _fileProvider = fileProvider;
 
             _method = null;
             _isGet = false;
@@ -134,7 +136,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         public bool LookupFileInfo()
         {
-            _fileInfo = _options.FileProvider.GetFileInfo(_subPath.Value);
+            _fileInfo = _fileProvider.GetFileInfo(_subPath.Value);
             if (_fileInfo.Exists)
             {
                 _length = _fileInfo.Length;

--- a/src/Microsoft.AspNetCore.StaticFiles/StaticFileContext.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/StaticFileContext.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         private readonly HttpResponse _response;
         private readonly ILogger _logger;
         private readonly IFileProvider _fileProvider;
+        private readonly IContentTypeProvider _contentTypeProvider;
         private string _method;
         private bool _isGet;
         private bool _isHead;
@@ -48,7 +49,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         private IList<RangeItemHeaderValue> _ranges;
 
-        public StaticFileContext(HttpContext context, StaticFileOptions options, PathString matchUrl, ILogger logger, IFileProvider fileProvider)
+        public StaticFileContext(HttpContext context, StaticFileOptions options, PathString matchUrl, ILogger logger, IFileProvider fileProvider, IContentTypeProvider contentTypeProvider)
         {
             _context = context;
             _options = options;
@@ -59,6 +60,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             _requestHeaders = _request.GetTypedHeaders();
             _responseHeaders = _response.GetTypedHeaders();
             _fileProvider = fileProvider;
+            _contentTypeProvider = contentTypeProvider;
 
             _method = null;
             _isGet = false;
@@ -120,7 +122,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
         public bool LookupContentType()
         {
-            if (_options.ContentTypeProvider.TryGetContentType(_subPath.Value, out _contentType))
+            if (_contentTypeProvider.TryGetContentType(_subPath.Value, out _contentType))
             {
                 return true;
             }

--- a/src/Microsoft.AspNetCore.StaticFiles/StaticFileMiddleware.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/StaticFileMiddleware.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
         private readonly IFileProvider _fileProvider;
+        private readonly IContentTypeProvider _contentTypeProvider;
 
         /// <summary>
         /// Creates a new instance of the StaticFileMiddleware.
@@ -53,13 +54,9 @@ namespace Microsoft.AspNetCore.StaticFiles
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            if (options.Value.ContentTypeProvider == null)
-            {
-                throw new ArgumentException(Resources.Args_NoContentTypeProvider);
-            }
-
             _next = next;
             _options = options.Value;
+            _contentTypeProvider = options.Value.ContentTypeProvider ?? new FileExtensionContentTypeProvider();
             _fileProvider = _options.FileProvider ?? Helpers.ResolveFileProvider(hostingEnv);
             _matchUrl = _options.RequestPath;
             _logger = loggerFactory.CreateLogger<StaticFileMiddleware>();
@@ -72,7 +69,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         /// <returns></returns>
         public Task Invoke(HttpContext context)
         {
-            var fileContext = new StaticFileContext(context, _options, _matchUrl, _logger, _fileProvider);
+            var fileContext = new StaticFileContext(context, _options, _matchUrl, _logger, _fileProvider, _contentTypeProvider);
           
             if (!fileContext.ValidateMethod())
             {

--- a/src/Microsoft.AspNetCore.StaticFiles/StaticFileMiddleware.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/StaticFileMiddleware.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -21,6 +22,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         private readonly PathString _matchUrl;
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
+        private readonly IFileProvider _fileProvider;
 
         /// <summary>
         /// Creates a new instance of the StaticFileMiddleware.
@@ -58,7 +60,7 @@ namespace Microsoft.AspNetCore.StaticFiles
 
             _next = next;
             _options = options.Value;
-            _options.ResolveFileProvider(hostingEnv);
+            _fileProvider = _options.FileProvider ?? Helpers.ResolveFileProvider(hostingEnv);
             _matchUrl = _options.RequestPath;
             _logger = loggerFactory.CreateLogger<StaticFileMiddleware>();
         }
@@ -70,7 +72,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         /// <returns></returns>
         public Task Invoke(HttpContext context)
         {
-            var fileContext = new StaticFileContext(context, _options, _matchUrl, _logger);
+            var fileContext = new StaticFileContext(context, _options, _matchUrl, _logger, _fileProvider);
           
             if (!fileContext.ValidateMethod())
             {

--- a/src/Microsoft.AspNetCore.StaticFiles/StaticFileOptions.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/StaticFileOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Options for serving static files
     /// </summary>
-    public class StaticFileOptions : SharedOptionsBase<StaticFileOptions>
+    public class StaticFileOptions : SharedOptionsBase
     {
         /// <summary>
         /// Defaults to all request paths

--- a/src/Microsoft.AspNetCore.StaticFiles/StaticFileOptions.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/StaticFileOptions.cs
@@ -25,8 +25,6 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="sharedOptions"></param>
         public StaticFileOptions(SharedOptions sharedOptions) : base(sharedOptions)
         {
-            ContentTypeProvider = new FileExtensionContentTypeProvider();
-
             OnPrepareResponse = _ => { };
         }
 

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
@@ -22,9 +22,10 @@ namespace Microsoft.AspNetCore.StaticFiles
         [Fact]
         public async Task NullArguments()
         {
-            Assert.Throws<ArgumentException>(() => StaticFilesTestServer.Create(
+            // No exception, default provided
+            StaticFilesTestServer.Create(
                 app => app.UseDirectoryBrowser(new DirectoryBrowserOptions { Formatter = null }),
-            services => services.AddDirectoryBrowser()));
+            services => services.AddDirectoryBrowser());
 
             // No exception, default provided
             StaticFilesTestServer.Create(

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileContextTest.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileContextTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         {
             // Arrange
             var options = new StaticFileOptions();
-            var context = new StaticFileContext(new DefaultHttpContext(), options, PathString.Empty, NullLogger.Instance, new TestFileProvider());
+            var context = new StaticFileContext(new DefaultHttpContext(), options, PathString.Empty, NullLogger.Instance, new TestFileProvider(), new FileExtensionContentTypeProvider());
 
             // Act
             var validateResult = context.ValidatePath();
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             var pathString = new PathString("/test");
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Path = new PathString("/test/foo.txt");
-            var context = new StaticFileContext(httpContext, options, pathString, NullLogger.Instance, fileProvider);
+            var context = new StaticFileContext(httpContext, options, pathString, NullLogger.Instance, fileProvider, new FileExtensionContentTypeProvider());
 
             // Act
             context.ValidatePath();

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileContextTest.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileContextTest.cs
@@ -21,8 +21,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         {
             // Arrange
             var options = new StaticFileOptions();
-            options.FileProvider = new TestFileProvider();
-            var context = new StaticFileContext(new DefaultHttpContext(), options, PathString.Empty, NullLogger.Instance);
+            var context = new StaticFileContext(new DefaultHttpContext(), options, PathString.Empty, NullLogger.Instance, new TestFileProvider());
 
             // Act
             var validateResult = context.ValidatePath();
@@ -43,11 +42,10 @@ namespace Microsoft.AspNetCore.StaticFiles
             {
                 LastModified = new DateTimeOffset(2014, 1, 2, 3, 4, 5, TimeSpan.Zero)
             });
-            options.FileProvider = fileProvider;
             var pathString = new PathString("/test");
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Path = new PathString("/test/foo.txt");
-            var context = new StaticFileContext(httpContext, options, pathString, NullLogger.Instance);
+            var context = new StaticFileContext(httpContext, options, pathString, NullLogger.Instance, fileProvider);
 
             // Act
             context.ValidatePath();

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileMiddlewareTests.cs
@@ -32,7 +32,8 @@ namespace Microsoft.AspNetCore.StaticFiles
         [Fact]
         public async Task NullArguments()
         {
-            Assert.Throws<ArgumentException>(() => StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions { ContentTypeProvider = null })));
+            // No exception, default provided
+            StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions { ContentTypeProvider = null }));
 
             // No exception, default provided
             StaticFilesTestServer.Create(app => app.UseStaticFiles(new StaticFileOptions { FileProvider = null }));


### PR DESCRIPTION
Middleware now initializes the default HtmlDirectoryFormatter

Part of https://github.com/aspnet/Coherence-Signed/issues/186

cc @lodejard 