### PR TITLE
Content type mapping for markdown

### DIFF
--- a/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
@@ -161,6 +161,8 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".man", "application/x-troff-man" },
                 { ".manifest", "application/x-ms-manifest" },
                 { ".map", "text/plain" },
+                { ".markdown", "text/markdown" },
+                { ".md", "text/markdown" },
                 { ".mdb", "application/x-msaccess" },
                 { ".mdp", "application/octet-stream" },
                 { ".me", "application/x-troff-me" },


### PR DESCRIPTION
Since it is now officially registered.

See: https://tools.ietf.org/html/rfc7763