### PR TITLE
Simplify configuring file extensions.

### DIFF
--- a/samples/StaticFileSample/Startup.cs
+++ b/samples/StaticFileSample/Startup.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -9,6 +11,17 @@ namespace StaticFilesSample
 {
     public class Startup
     {
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true);
+
+            Configuration = builder.Build();
+        }
+
+        public IConfigurationRoot Configuration { get; }
+
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDirectoryBrowser();
@@ -21,10 +34,43 @@ namespace StaticFilesSample
             // Displays all log levels
             factory.AddConsole(LogLevel.Debug);
 
-            app.UseFileServer(new FileServerOptions
+            // Just static files
+            app.UseStaticFiles(new StaticFileOptions()
             {
-                EnableDirectoryBrowsing = true
+                OnPrepareResponse = context => { },
+                ContentTypeProvider = LoadFromConfig(new FileExtensionContentTypeProvider())
+                    .SetFileType(".custom", "custom/type")
+                    .RemoveFileType(".foo")
             });
+
+            // Static files, default files, and directory browsing
+            app.UseFileServer(new FileServerOptions()
+            {
+                EnableDirectoryBrowsing = true,
+                ContentTypeProvider = new FileExtensionContentTypeProvider()
+                    .SetFileType(".custom", "custom/type")
+                    .RemoveFileType(".foo")
+            });
+        }
+
+        private FileExtensionContentTypeProvider LoadFromConfig(FileExtensionContentTypeProvider contentTypes)
+        {
+            var clear = Configuration["staticfiles:extensions:clear"];
+            if (string.Equals(clear, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                contentTypes.Clear();
+            }
+            foreach (var pair in Configuration.GetSection("staticfiles:extensions:add")?.GetChildren())
+            {
+                // { ".foo": "app/bar" }
+                contentTypes.SetFileType(pair.Key, pair.Value);
+            }
+            foreach (var pair in Configuration.GetSection("staticfiles:extensions:remove")?.GetChildren())
+            {
+                // { "0": ".foo" }
+                contentTypes.RemoveFileType(pair.Value);
+            }
+            return contentTypes;
         }
 
         public static void Main(string[] args)

--- a/samples/StaticFileSample/appsettings.json
+++ b/samples/StaticFileSample/appsettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "staticfiles": {
+    "extensions": {
+      "add": {
+        ".extra": "application/custom"
+      },
+      "remove": [ ".foo", ".bar" ]
+    }
+  }
+}

--- a/samples/StaticFileSample/project.json
+++ b/samples/StaticFileSample/project.json
@@ -6,6 +6,7 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.1.0-*",
+    "Microsoft.Extensions.Configuration.Json": "1.1.0-*",
     "Microsoft.Extensions.Logging.Console": "1.1.0-*"
   },
   "frameworks": {

--- a/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
@@ -455,5 +455,38 @@ namespace Microsoft.AspNetCore.StaticFiles
 
             return path.Substring(index);
         }
+
+        /// <summary>
+        /// Add or overwrite a map between file extension and MIME type.
+        /// </summary>
+        /// <param name="extension"></param>
+        /// <param name="mimeType"></param>
+        /// <returns></returns>
+        public FileExtensionContentTypeProvider SetFileType(string extension, string mimeType)
+        {
+            Mappings[extension] = mimeType;
+            return this;
+        }
+
+        /// <summary>
+        /// Remove a file extension from the list.
+        /// </summary>
+        /// <param name="extension"></param>
+        /// <returns></returns>
+        public FileExtensionContentTypeProvider RemoveFileType(string extension)
+        {
+            Mappings.Remove(extension);
+            return this;
+        }
+
+        /// <summary>
+        /// Clear all file extensions from the list.
+        /// </summary>
+        /// <returns></returns>
+        public FileExtensionContentTypeProvider Clear()
+        {
+            Mappings.Clear();
+            return this;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.StaticFiles/FileServerOptions.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileServerOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.AspNetCore.StaticFiles.Infrastructure;
 
 namespace Microsoft.AspNetCore.Builder
@@ -46,5 +47,15 @@ namespace Microsoft.AspNetCore.Builder
         /// Default files are enabled by default.
         /// </summary>
         public bool EnableDefaultFiles { get; set; }
+
+        // Directly exposed so it can be assigned via the constructor initializer syntax.
+        /// <summary>
+        /// Used to map files to content-types.
+        /// </summary>
+        public IContentTypeProvider ContentTypeProvider
+        {
+            get { return StaticFileOptions.ContentTypeProvider; }
+            set { StaticFileOptions.ContentTypeProvider = value; }
+        }
     }
 }


### PR DESCRIPTION
#129 @muratg @davidfowl @glennc 
@DamianEdwards I added sample code for loading extensions from config.

Old sample code:
```
            var options = new FileServerOptions
            {
                EnableDirectoryBrowsing = true, // Unrelated, but common
            };
 
            var contentTypes = new FileExtensionContentTypeProvider();
            contentTypes.Mappings[".custom"] = "custom/type";
            contentTypes.Mappings.Remove(".custom");
            options.StaticFileOptions.ContentTypeProvider = contentTypes;
 
            app.UseFileServer(options);
 
            var contentTypes = new FileExtensionContentTypeProvider();
            contentTypes.Mappings[".custom"] = "custom/type";
            contentTypes.Mappings.Remove(".custom");
 
            app.UseStaticFiles(new StaticFileOptions
            {
                ContentTypeProvider = contentTypes,
                OnPrepareResponse = _ => { }
            });
```

New code:
```
            app.UseStaticFiles(new StaticFileOptions
            {
                OnPrepareResponse = context => { },
                ContentTypeProvider = new FileExtensionContentTypeProvider()
                    .SetFileType(".custom", "custom/type")
                    .RemoveFileType(".foo")
            });

            app.UseFileServer(new FileServerOptions
            {
                EnableDirectoryBrowsing = true,
                ContentTypeProvider = new FileExtensionContentTypeProvider()
                    .SetFileType(".custom", "custom/type")
                    .RemoveFileType(".foo")
            });
```