### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.AspNetCore.StaticFiles.FunctionalTests/Microsoft.AspNetCore.StaticFiles.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.StaticFiles.FunctionalTests/Microsoft.AspNetCore.StaticFiles.FunctionalTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/Microsoft.AspNetCore.StaticFiles.Tests.csproj
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/Microsoft.AspNetCore.StaticFiles.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFilesTestServer.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFilesTestServer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.StaticFiles
     {
         public static TestServer Create(Action<IApplicationBuilder> configureApp, Action<IServiceCollection> configureServices = null)
         {
-            var contentRootNet451 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            var contentRootNet452 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                 "." : "../../../../test/Microsoft.AspNetCore.StaticFiles.Tests";
             Action<IServiceCollection> defaultConfigureServices = services => { };
             var configuration = new ConfigurationBuilder()
@@ -26,8 +26,8 @@ namespace Microsoft.AspNetCore.StaticFiles
                 })
                 .Build();
             var builder = new WebHostBuilder()
-#if NET451
-                .UseContentRoot(contentRootNet451)
+#if NET452
+                .UseContentRoot(contentRootNet452)
 #endif
                 .UseConfiguration(configuration)
                 .Configure(configureApp)

--- a/test/shared/TestBaseDir.cs
+++ b/test/shared/TestBaseDir.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.StaticFiles
     public static class TestDirectory
     {
         public static readonly string BaseDirectory
-#if NET451
+#if NET452
         = AppDomain.CurrentDomain.BaseDirectory;
 #else
         = AppContext.BaseDirectory;


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows