### PR TITLE
Update test framework versions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <AspNetIntegrationTestingVersion>0.4.0-*</AspNetIntegrationTestingVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.RangeHelper.Sources.Test/Microsoft.AspNetCore.RangeHelper.Sources.Test.csproj
+++ b/test/Microsoft.AspNetCore.RangeHelper.Sources.Test/Microsoft.AspNetCore.RangeHelper.Sources.Test.csproj
@@ -18,8 +18,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.RangeHelper.Sources.Test/RangeHelperTests.cs
+++ b/test/Microsoft.AspNetCore.RangeHelper.Sources.Test/RangeHelperTests.cs
@@ -75,11 +75,9 @@ namespace Microsoft.AspNetCore.Internal
         }
 
         [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, 0)]
-        [InlineData(0, null)]
-        [InlineData(0, 0)]
-        public void NormalizeRanges_ReturnsNormalizedRange(long? start, long? end)
+        [InlineData(0, null, 0, 2)]
+        [InlineData(0, 0, 0, 0)]
+        public void NormalizeRanges_ReturnsNormalizedRange(long? start, long? end, long? normalizedStart, long? normalizedEnd)
         {
             // Arrange
             var ranges = new[]
@@ -88,12 +86,12 @@ namespace Microsoft.AspNetCore.Internal
             };
 
             // Act
-            var normalizedRanges = RangeHelper.NormalizeRanges(ranges, 1);
+            var normalizedRanges = RangeHelper.NormalizeRanges(ranges, 3);
 
             // Assert
             var range = Assert.Single(normalizedRanges);
-            Assert.Equal(0, range.From);
-            Assert.Equal(0, range.To);
+            Assert.Equal(normalizedStart, range.From);
+            Assert.Equal(normalizedEnd, range.To);
         }
 
         [Fact]
@@ -115,11 +113,9 @@ namespace Microsoft.AspNetCore.Internal
         }
 
         [Theory]
-        [InlineData(null, null)]
-        [InlineData(null, 0)]
-        [InlineData(0, null)]
-        [InlineData(0, 0)]
-        public void NormalizeRanges_MultipleRanges_ReturnsNormalizedRange(long? start, long? end)
+        [InlineData(0, null, 0, 2)]
+        [InlineData(0, 0, 0, 0)]
+        public void NormalizeRanges_MultipleRanges_ReturnsNormalizedRange(long? start, long? end, long? normalizedStart, long? normalizedEnd)
         {
             // Arrange
             var ranges = new[]
@@ -135,8 +131,8 @@ namespace Microsoft.AspNetCore.Internal
             Assert.Collection(normalizedRanges,
                 range =>
                 {
-                    Assert.Equal(0, range.From);
-                    Assert.Equal(0, range.To);
+                    Assert.Equal(normalizedStart, range.From);
+                    Assert.Equal(normalizedEnd, range.To);
                 },
                 range =>
                 {

--- a/test/Microsoft.AspNetCore.RangeHelper.Sources.Test/RangeHelperTests.cs
+++ b/test/Microsoft.AspNetCore.RangeHelper.Sources.Test/RangeHelperTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Internal
         [InlineData(null, 0)]
         [InlineData(0, null)]
         [InlineData(0, 0)]
-        public void NormalizeRanges_ReturnsNormalizedRange(long start, long end)
+        public void NormalizeRanges_ReturnsNormalizedRange(long? start, long? end)
         {
             // Arrange
             var ranges = new[]
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Internal
         [InlineData(null, 0)]
         [InlineData(0, null)]
         [InlineData(0, 0)]
-        public void NormalizeRanges_MultipleRanges_ReturnsNormalizedRange(long start, long end)
+        public void NormalizeRanges_MultipleRanges_ReturnsNormalizedRange(long? start, long? end)
         {
             // Arrange
             var ranges = new[]

--- a/test/Microsoft.AspNetCore.StaticFiles.FunctionalTests/Microsoft.AspNetCore.StaticFiles.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.StaticFiles.FunctionalTests/Microsoft.AspNetCore.StaticFiles.FunctionalTests.csproj
@@ -32,8 +32,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.StaticFiles.FunctionalTests/StaticFileMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.FunctionalTests/StaticFileMiddlewareTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 {
                     var last = File.GetLastWriteTimeUtc(Path.Combine(AppContext.BaseDirectory, "TestDocument.txt"));
                     var response = await client.GetAsync("TestDocument.txt");
-                    
+
                     var trimed = new DateTimeOffset(last.Year, last.Month, last.Day, last.Hour, last.Minute, last.Second, TimeSpan.Zero).ToUniversalTime();
 
                     Assert.Equal(response.Content.Headers.LastModified.Value, trimed);
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await FoundFile_Served(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task FoundFile_Served(string baseUrl, string baseDir, string requestUrl)
+        private async Task FoundFile_Served(string baseUrl, string baseDir, string requestUrl)
         {
             var baseAddress = "http://localhost:12345";
             var builder = new WebHostBuilder()
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             ClientDisconnect_NoWriteExceptionThrown(ServerType.WebListener);
         }
 
-        public void ClientDisconnect_NoWriteExceptionThrown(ServerType serverType)
+        private void ClientDisconnect_NoWriteExceptionThrown(ServerType serverType)
         {
             var interval = TimeSpan.FromSeconds(15);
             var baseAddress = "http://localhost:12345";

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/DefaultFilesMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/DefaultFilesMiddlewareTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await NoMatch_PassesThrough(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task NoMatch_PassesThrough(string baseUrl, string baseDir, string requestUrl)
+        private async Task NoMatch_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await FoundDirectoryWithDefaultFile_PathModified(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task FoundDirectoryWithDefaultFile_PathModified(string baseUrl, string baseDir, string requestUrl)
+        private async Task FoundDirectoryWithDefaultFile_PathModified(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await NearMatch_RedirectAddSlash(baseUrl, baseDir, requestUrl, queryString);
         }
 
-        public async Task NearMatch_RedirectAddSlash(string baseUrl, string baseDir, string requestUrl, string queryString)
+        private async Task NearMatch_RedirectAddSlash(string baseUrl, string baseDir, string requestUrl, string queryString)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await PostDirectory_PassesThrough(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task PostDirectory_PassesThrough(string baseUrl, string baseDir, string requestUrl)
+        private async Task PostDirectory_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvder = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/DirectoryBrowserMiddlewareTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await NoMatch_PassesThrough(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task NoMatch_PassesThrough(string baseUrl, string baseDir, string requestUrl)
+        private async Task NoMatch_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await FoundDirectory_Served(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task FoundDirectory_Served(string baseUrl, string baseDir, string requestUrl)
+        private async Task FoundDirectory_Served(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await NearMatch_RedirectAddSlash(baseUrl, baseDir, requestUrl, queryString);
         }
 
-        public async Task NearMatch_RedirectAddSlash(string baseUrl, string baseDir, string requestUrl, string queryString)
+        private async Task NearMatch_RedirectAddSlash(string baseUrl, string baseDir, string requestUrl, string queryString)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await PostDirectory_PassesThrough(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task PostDirectory_PassesThrough(string baseUrl, string baseDir, string requestUrl)
+        private async Task PostDirectory_PassesThrough(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await HeadDirectory_HeadersButNotBodyServed(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task HeadDirectory_HeadersButNotBodyServed(string baseUrl, string baseDir, string requestUrl)
+        private async Task HeadDirectory_HeadersButNotBodyServed(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/Microsoft.AspNetCore.StaticFiles.Tests.csproj
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/Microsoft.AspNetCore.StaticFiles.Tests.csproj
@@ -26,8 +26,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.StaticFiles.Tests/StaticFileMiddlewareTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.StaticFiles
             await FoundFile_Served(baseUrl, baseDir, requestUrl);
         }
 
-        public async Task FoundFile_Served(string baseUrl, string baseDir, string requestUrl)
+        private async Task FoundFile_Served(string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.StaticFiles
         public async Task Unknown_Match_PassesThrough(string baseUrl, string baseDir, string requestUrl) =>
             await PassesThrough("VERB", baseUrl, baseDir, requestUrl);
 
-        public async Task PassesThrough(string method, string baseUrl, string baseDir, string requestUrl)
+        private async Task PassesThrough(string method, string baseUrl, string baseDir, string requestUrl)
         {
             using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, baseDir)))
             {


### PR DESCRIPTION
This uncovered a test issue. @jbagga can you provide guidance on how to fix the tests?

I fixed the input type for the NormalizeRanges_ReturnsNormalizedRange and NormalizeRanges_MultipleRanges_ReturnsNormalizedRange tests to be `long?` as `long` cannot be null. These tests fail now. I'm not sure what the expected behavior is.