### PR TITLE
Update FileExtensionContentTypeProvider.cs...

### DIFF
--- a/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
+++ b/src/Microsoft.AspNetCore.StaticFiles/FileExtensionContentTypeProvider.cs
@@ -338,6 +338,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".wcm", "application/vnd.ms-works" },
                 { ".wdb", "application/vnd.ms-works" },
                 { ".webm", "video/webm" },
+                { ".webmanifest", "application/manifest+json" },
                 { ".webp", "image/webp" },
                 { ".wks", "application/vnd.ms-works" },
                 { ".wm", "video/x-ms-wm" },


### PR DESCRIPTION
...to support .webmanifest file extension, using the `application/manifest+json` content type. This is used to light up progressive web apps.

https://www.w3.org/TR/appmanifest/

